### PR TITLE
Allow file:// style urls in addition to http://

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 #
 define download_file ($url, $destination_directory, $proxyAddress='') {
-  $filename = regsubst($url, '^http.*\/([^\/]+)$', '\1')
+  $filename = regsubst($url, '^(http|file).*\/([^\/]+)$', '\2')
   $powershell_filename = regsubst($url, '^(.*\/)(.+?)(?:\.[^\.]*$|$)$', '\2')
 
   validate_re($url, '.+')


### PR DESCRIPTION
 - For the sake of demonstrating the nsclient module at PuppetConf, I'm trying not to rely on the network.
   Therefore, I'd like to serve the file from the Vagrant synced_folder share, rather than over HTTPS, like:

```puppet
   class { 'nsclient':
     package_source_location => 'file://C:/vagrant/modules/nsclient/files',
     package_source          => 'NSCP-0.4.1.105-x64.msi'
   }
```

   Without the included change, file style urls don't properly parse.