### PR TITLE
Add fields for proxy credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ The optional name of the file to download onto the system.
 #####`proxyAddress`
 The optional http proxy address to use when downloading the file
 
+#####`proxyUser`
+The optional http proxy user to use when downloading the file. `proxyAddress` and `proxyPassword`
+must be specified or this has no effect.
+
+#####`proxyPassword`
+The optional http proxy password to use when downloading the file. `proxyAddress` and `proxyUser`
+must be specified or this has no effect. By default this value accepts secure strings. A secure
+string is (unfortunately) tied to the machine that it is ued for. To generate a secure string for
+a given machine, users should run the following powershell command on that machine (replacing
+PASSWORD with the desired password):
+
+```Powershell
+ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "PASSWORD" -AsPlainText -Force)
+```
+
+It is possible to get this information then clear the command from history, but it's important to
+note that the -Force argument is there to suppress warnings that the plaintext password is in
+the history.
+
+If this process sounds unappealing, you can send the password in plaintext (which sits in the
+download-<filename>.ps1 file on the machine being provisioned) by changing the `isPasswordSecure`
+variable to `false`.
+
+#####`isPasswordSecure`
+The optional switch to change the way that `proxyPassword` is interpreted from secure string to
+plaintext. This will send the password in plaintext to the machine being provisioned, which may
+be a security concern.
+
 ##Reference
 
 ###Defined Types
@@ -87,6 +115,8 @@ This module is tested on the following platforms:
 * Windows 2008 R2
 * Windows 2012
 * Windows 2012 R2
+* Windows 7
+* Windows 8
 
 It is tested with the OSS version of Puppet only.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,10 @@ define download_file(
   $url,
   $destination_directory,
   $destination_file = '',
-  $proxyAddress=''
+  $proxyAddress='',
+  $proxyUser='',
+  $proxyPassword='',
+  $isPasswordSecure=true
 ) {
 
   if "x${destination_file}x" == 'xx' {

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "operatingsystem_support": [
     {
     "operatingsystem":"Windows",
-    "operatingsystemrelease":[ "2008R2", "2012", "2012R2" ]
+    "operatingsystemrelease":[ "2008R2", "2012", "2012R2", "7", "8" ]
     }
   ],
   "dependencies": [

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -36,26 +36,27 @@ describe 'download_file', :type => :define do
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = ''
       $proxyUser = ''
-      
-      
       $proxyPassword = ''
-      
-      
+
       if ($proxyAddress -ne '') {
-        if (!$proxyAddress.StartsWith('http://')) {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-      
+
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+        
+          
           $password = ConvertTo-SecureString -string $proxyPassword
+          
+          
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
         $webclient.proxy = $proxy
       }
-      
+
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }
@@ -96,26 +97,27 @@ describe 'download_file', :type => :define do
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = 'test-proxy-01:8888'
       $proxyUser = ''
-      
-      
       $proxyPassword = ''
-      
-      
+
       if ($proxyAddress -ne '') {
-        if (!$proxyAddress.StartsWith('http://')) {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-      
+
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+        
+          
           $password = ConvertTo-SecureString -string $proxyPassword
+          
+          
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
         $webclient.proxy = $proxy
       }
-      
+
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }
@@ -139,7 +141,6 @@ describe 'download_file', :type => :define do
       :proxyUser => 'test-user',
       :proxyPassword => 'test-secure'
     }}
-
     it { should contain_exec('download-test.exe').with({
       'command' => "c:\\temp\\download-test.ps1",
       'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
@@ -160,26 +161,27 @@ describe 'download_file', :type => :define do
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = 'test-proxy-01:8888'
       $proxyUser = 'test-user'
-      
-      
       $proxyPassword = 'test-secure'
-      
-      
+
       if ($proxyAddress -ne '') {
-        if (!$proxyAddress.StartsWith('http://')) {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-      
+
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+        
+          
           $password = ConvertTo-SecureString -string $proxyPassword
+          
+          
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
         $webclient.proxy = $proxy
       }
-      
+
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }
@@ -226,31 +228,27 @@ describe 'download_file', :type => :define do
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = 'test-proxy-01:8888'
       $proxyUser = 'test-user'
-      
-      
-      if ('test' -ne '') - {
-        $proxyPassword = ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "test" -AsPlainText -Force)
-      }
-      else {
-        $proxyPassword = ''
-      }
-      
-      
+      $proxyPassword = 'test'
+
       if ($proxyAddress -ne '') {
-        if (!$proxyAddress.StartsWith('http://')) {
+        if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-      
+
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
         if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
-          $password = ConvertTo-SecureString -string $proxyPassword
+        
+          
+          $password = ConvertTo-SecureString "$proxyPassword" -AsPlainText -Force
+          
+          
           $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
           $webclient.UseDefaultCredentials = $true
         }
         $webclient.proxy = $proxy
       }
-      
+
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }

--- a/spec/defines/download_file_spec.rb
+++ b/spec/defines/download_file_spec.rb
@@ -35,16 +35,27 @@ describe 'download_file', :type => :define do
     ps1 = <<-PS1.gsub(/^ {6}/, '')
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = ''
+      $proxyUser = ''
+      
+      
+      $proxyPassword = ''
+      
+      
       if ($proxyAddress -ne '') {
         if (!$proxyAddress.StartsWith('http://')) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-
+      
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+          $password = ConvertTo-SecureString -string $proxyPassword
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
         $webclient.proxy = $proxy
       }
-
+      
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }
@@ -59,7 +70,7 @@ describe 'download_file', :type => :define do
     it { should contain_file('download-test.exe.ps1').with_content(ps1) }
   end
 
-  describe 'when downloading a file using a proxy server' do
+  describe 'when downloading a file using a proxy server without credentials' do
     let(:title)  { 'Download DotNet 4.0' }
     let(:params) {{
       :url => 'http://myserver.com/test.exe',
@@ -73,7 +84,7 @@ describe 'download_file', :type => :define do
     })}
   end
 
-  describe 'when downloading a file using a proxy server we want to check that the erb gets evaluated correctly' do
+  describe 'when downloading a file using a proxy server without credentials we want to check that the erb gets evaluated correctly' do
     let(:title)  { 'Download DotNet 4.0' }
     let(:params) {{
       :url => 'http://myserver.com/test.exe',
@@ -84,16 +95,162 @@ describe 'download_file', :type => :define do
     ps1 = <<-PS1.gsub(/^ {6}/, '')
       $webclient = New-Object System.Net.WebClient
       $proxyAddress = 'test-proxy-01:8888'
+      $proxyUser = ''
+      
+      
+      $proxyPassword = ''
+      
+      
       if ($proxyAddress -ne '') {
         if (!$proxyAddress.StartsWith('http://')) {
           $proxyAddress = 'http://' + $proxyAddress
         }
-
+      
         $proxy = new-object System.Net.WebProxy
         $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+          $password = ConvertTo-SecureString -string $proxyPassword
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
         $webclient.proxy = $proxy
       }
+      
+      try {
+        $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
+      }
+      catch [Exception] {
+        write-host $_.Exception.GetType().FullName
+        write-host $_.Exception.Message
+        write-host $_.Exception.InnerException.Message
+        throw $_.Exception
+      }
+    PS1
 
+    it { should contain_file('download-test.exe.ps1').with_content(ps1) }
+	end
+
+  describe 'when downloading a file using a proxy server with credentials' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) {{
+      :url => 'http://myserver.com/test.exe',
+      :destination_directory => 'c:\temp',
+      :proxyAddress => 'test-proxy-01:8888',
+      :proxyUser => 'test-user',
+      :proxyPassword => 'test-secure'
+    }}
+
+    it { should contain_exec('download-test.exe').with({
+      'command' => "c:\\temp\\download-test.ps1",
+      'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
+    })}
+  end
+
+  describe 'when downloading a file using a proxy server with secure credentials we want to check that the erb gets evaluated correctly' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) {{
+      :url => 'http://myserver.com/test.exe',
+      :destination_directory => 'c:\temp',
+      :proxyAddress => 'test-proxy-01:8888',
+      :proxyUser => 'test-user',
+      :proxyPassword => 'test-secure'
+    }}
+
+    ps1 = <<-PS1.gsub(/^ {6}/, '')
+      $webclient = New-Object System.Net.WebClient
+      $proxyAddress = 'test-proxy-01:8888'
+      $proxyUser = 'test-user'
+      
+      
+      $proxyPassword = 'test-secure'
+      
+      
+      if ($proxyAddress -ne '') {
+        if (!$proxyAddress.StartsWith('http://')) {
+          $proxyAddress = 'http://' + $proxyAddress
+        }
+      
+        $proxy = new-object System.Net.WebProxy
+        $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+          $password = ConvertTo-SecureString -string $proxyPassword
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
+        $webclient.proxy = $proxy
+      }
+      
+      try {
+        $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
+      }
+      catch [Exception] {
+        write-host $_.Exception.GetType().FullName
+        write-host $_.Exception.Message
+        write-host $_.Exception.InnerException.Message
+        throw $_.Exception
+      }
+    PS1
+
+    it { should contain_file('download-test.exe.ps1').with_content(ps1) }
+	end
+
+  describe 'when downloading a file using a proxy server with insecure credentials' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) {{
+      :url => 'http://myserver.com/test.exe',
+      :destination_directory => 'c:\temp',
+      :proxyAddress => 'test-proxy-01:8888',
+      :proxyUser => 'test-user',
+      :proxyPassword => 'test',
+      :isPasswordSecure => false
+    }}
+
+    it { should contain_exec('download-test.exe').with({
+      'command' => "c:\\temp\\download-test.ps1",
+      'onlyif'  => "if(Test-Path -Path 'c:\\temp\\test.exe') { exit 1 } else { exit 0 }",
+    })}
+  end
+
+  describe 'when downloading a file using a proxy server with insecure credentials we want to check that the erb gets evaluated correctly' do
+    let(:title)  { 'Download DotNet 4.0' }
+    let(:params) {{
+      :url => 'http://myserver.com/test.exe',
+      :destination_directory => 'c:\temp',
+      :proxyAddress => 'test-proxy-01:8888',
+      :proxyUser => 'test-user',
+      :proxyPassword => 'test',
+      :isPasswordSecure => false
+    }}
+
+    ps1 = <<-PS1.gsub(/^ {6}/, '')
+      $webclient = New-Object System.Net.WebClient
+      $proxyAddress = 'test-proxy-01:8888'
+      $proxyUser = 'test-user'
+      
+      
+      if ('test' -ne '') - {
+        $proxyPassword = ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "test" -AsPlainText -Force)
+      }
+      else {
+        $proxyPassword = ''
+      }
+      
+      
+      if ($proxyAddress -ne '') {
+        if (!$proxyAddress.StartsWith('http://')) {
+          $proxyAddress = 'http://' + $proxyAddress
+        }
+      
+        $proxy = new-object System.Net.WebProxy
+        $proxy.Address = $proxyAddress
+        if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+          $password = ConvertTo-SecureString -string $proxyPassword
+          $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+          $webclient.UseDefaultCredentials = $true
+        }
+        $webclient.proxy = $proxy
+      }
+      
       try {
         $webclient.DownloadFile('http://myserver.com/test.exe', 'c:\\temp\\test.exe')
       }

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -1,27 +1,23 @@
 $webclient = New-Object System.Net.WebClient
 $proxyAddress = '<%= @proxyAddress %>'
 $proxyUser = '<%= @proxyUser %>'
-
-<% if @isPasswordSecure %>
 $proxyPassword = '<%= @proxyPassword %>'
-<% else %>
-if ('<%= @proxyPassword %>' -ne '') - {
-  $proxyPassword = ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "<%= @proxyPassword %>" -AsPlainText -Force)
-}
-else {
-  $proxyPassword = ''
-}
-<% end %>
 
 if ($proxyAddress -ne '') {
-  if (!$proxyAddress.StartsWith('http://')) {
+  if (!($proxyAddress.StartsWith('http://') -or $proxyAddress.StartsWith('https://'))) {
     $proxyAddress = 'http://' + $proxyAddress
   }
 
   $proxy = new-object System.Net.WebProxy
   $proxy.Address = $proxyAddress
   if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+  
+    <% if @isPasswordSecure %>
     $password = ConvertTo-SecureString -string $proxyPassword
+    <% else %>
+    $password = ConvertTo-SecureString "$proxyPassword" -AsPlainText -Force
+    <% end %>
+    
     $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
     $webclient.UseDefaultCredentials = $true
   }

--- a/templates/download.ps1.erb
+++ b/templates/download.ps1.erb
@@ -1,5 +1,18 @@
 $webclient = New-Object System.Net.WebClient
 $proxyAddress = '<%= @proxyAddress %>'
+$proxyUser = '<%= @proxyUser %>'
+
+<% if @isPasswordSecure %>
+$proxyPassword = '<%= @proxyPassword %>'
+<% else %>
+if ('<%= @proxyPassword %>' -ne '') - {
+  $proxyPassword = ConvertFrom-SecureString -securestring $(ConvertTo-SecureString "<%= @proxyPassword %>" -AsPlainText -Force)
+}
+else {
+  $proxyPassword = ''
+}
+<% end %>
+
 if ($proxyAddress -ne '') {
   if (!$proxyAddress.StartsWith('http://')) {
     $proxyAddress = 'http://' + $proxyAddress
@@ -7,6 +20,11 @@ if ($proxyAddress -ne '') {
 
   $proxy = new-object System.Net.WebProxy
   $proxy.Address = $proxyAddress
+  if (($proxyPassword -ne '') -and ($proxyUser -ne '')) {
+    $password = ConvertTo-SecureString -string $proxyPassword
+    $proxy.Credentials = New-Object System.Management.Automation.PSCredential($proxyUser, $password)
+    $webclient.UseDefaultCredentials = $true
+  }
   $webclient.proxy = $proxy
 }
 


### PR DESCRIPTION
- proxyUser and proxyPassword must both be specified for credential proxy user.
- proxyPassword must be a securestring unless isProxySecure is manually set false
- Add Windows 7 and 8 support to metadata.json
- Change Readme to reflect Windows 7 and 8 support
- Update readme to reflect new variables
- Add erb validation tests and fix previous erb tests